### PR TITLE
Remove "container" metricset from metricbeat docker module

### DIFF
--- a/eim/ansible/beats/setup-files/metricbeat.yml
+++ b/eim/ansible/beats/setup-files/metricbeat.yml
@@ -3,7 +3,7 @@
 # Custom fields
 metricbeat.modules:
 - module: docker
-  metricsets: ["container", "cpu", "diskio", "healthcheck", "info", "memory", "network"]
+  metricsets: ["cpu", "diskio", "healthcheck", "info", "memory", "network"]
   hosts: ["unix:///var/run/docker.sock"]
   enabled: true
   period: 10s


### PR DESCRIPTION
Remove "container" metricset from metricbeat docker module (Unused in ET Graphs)