### PR TITLE
Improve delete process to let the SUT as default

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -26,6 +26,7 @@ services:
             - ET_EDM_MYSQL_HOST=eim-mysql
             - ET_EDM_MYSQL_PORT=3306
             - WAIT_HOSTS=eim-mysql:3306
+            - PASS=elastest
         expose:
             - 8080
         ports:

--- a/eim/Dockerfile
+++ b/eim/Dockerfile
@@ -75,6 +75,7 @@ COPY ansible/beats/setup-files/packetbeat.yml /var/ansible/beats/setup-files
 # beats - EXECBEAT
 COPY ansible/beats/playbook-install-beat-execbeat.yml /var/ansible/beats
 COPY ansible/beats/setup-files/execbeat.yml /var/ansible/beats/setup-files
+COPY ansible/beats/remove_iptables_rules.sh /var/ansible/beats
 
 # restart tomcat server to refresh the value of the properties 
 COPY tomcat/restart_tomcat.sh /var/tomcat/restart_tomcat.sh

--- a/eim/ansible/beats/playbook-delete-beats-template.yml
+++ b/eim/ansible/beats/playbook-delete-beats-template.yml
@@ -2,6 +2,8 @@
 # file: playbook-delete-beats-output-logstash-template.yml
 
 - hosts: ##targethost##
+  vars:
+    AGENT_ID: ##targethost##
   remote_user: ##user##
   become: yes
   tasks:
@@ -47,6 +49,16 @@
       path: /etc/execbeat/
       state: absent
     when: service_status_execbeat.stat.exists == true
+
+  - name: Check if iptables list is not empty
+    command: sudo iptables --list --line-numbers
+    register: iptables_lists_exists
+  
+  - name: "Restore default iptables rules of SUT"
+    shell: sudo iptables -D {{ item }}
+    with_items: 
+      -  "##item##"
+    when: iptables_lists_exists!="0"
 
   - name: remove packetbeat
     apt:

--- a/eim/ansible/beats/remove_iptables_rules.sh
+++ b/eim/ansible/beats/remove_iptables_rules.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+mysql -u root -p"$PASS" -h "$ET_EDM_MYSQL_HOST" <<EOF
+
+echo "Use EIM ..."
+USE EIM
+echo "Running queries ..."
+tam="SELECT count(*) FROM agent_configuration_control WHERE 'PACKETLOSS'>0;"
+agent="SELECT '$AGENT_ID' FROM agent_configuration_control;"
+
+for i in "$agent"; do
+  for i in "$tam"; do
+   	iptable_rule=mysql -e "SELECT 'PACKETLOSS' FROM agent_configuration_control;"
+  	sudo iptables -D "$iptable_rule"
+  	"DELETE FROM agent_configuration_control WHERE AGENT_ID=$agent;"
+   done
+done
+
+echo "Rules of SUT reseted"
+EOF

--- a/eim/eim-rest-api/logs/eim-rest-api.log
+++ b/eim/eim-rest-api/logs/eim-rest-api.log
@@ -849,3 +849,213 @@
 2019-04-24 15:30:36 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
 2019-04-24 15:30:36 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
 2019-04-24 15:30:36 ERROR EimDbCreator:141 - null
+2019-04-25 20:11:24 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-04-25 20:11:24 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-04-25 20:11:24 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-04-25 20:11:24 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-04-25 20:11:24 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-04-25 20:11:24 ERROR EimDbCreator:141 - null
+2019-04-25 20:11:24 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-04-25 20:11:24 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-04-25 20:11:24 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-04-25 20:11:24 ERROR EimDbCreator:141 - null
+2019-04-25 20:11:24 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-04-25 20:11:24 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-04-25 20:11:24 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-04-25 20:11:24 ERROR EimDbCreator:141 - null
+2019-05-14 11:44:59 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-14 11:44:59 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-14 11:44:59 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-14 11:44:59 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-14 11:44:59 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-14 11:44:59 ERROR EimDbCreator:141 - null
+2019-05-14 11:44:59 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-14 11:44:59 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-14 11:44:59 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-14 11:44:59 ERROR EimDbCreator:141 - null
+2019-05-14 11:44:59 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-14 11:44:59 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-14 11:44:59 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-14 11:44:59 ERROR EimDbCreator:141 - null
+2019-05-14 11:46:13 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-14 11:46:13 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-14 11:46:13 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-14 11:46:13 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-14 11:46:13 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-14 11:46:13 ERROR EimDbCreator:141 - null
+2019-05-14 11:46:13 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-14 11:46:13 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-14 11:46:13 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-14 11:46:13 ERROR EimDbCreator:141 - null
+2019-05-14 11:46:13 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-14 11:46:13 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-14 11:46:13 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-14 11:46:13 ERROR EimDbCreator:141 - null
+2019-05-14 13:18:49 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-14 13:18:49 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-14 13:18:49 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-14 13:18:49 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-14 13:18:49 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-14 13:18:49 ERROR EimDbCreator:141 - null
+2019-05-14 13:18:49 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-14 13:18:49 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-14 13:18:49 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-14 13:18:49 ERROR EimDbCreator:141 - null
+2019-05-14 13:18:49 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-14 13:18:49 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-14 13:18:49 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-14 13:18:49 ERROR EimDbCreator:141 - null
+2019-05-15 12:06:17 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-15 12:06:18 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-15 12:06:18 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-15 12:06:18 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-15 12:06:18 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 12:06:18 ERROR EimDbCreator:141 - null
+2019-05-15 12:06:18 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-15 12:06:18 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-15 12:06:18 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 12:06:18 ERROR EimDbCreator:141 - null
+2019-05-15 12:06:18 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-15 12:06:18 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-15 12:06:18 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 12:06:18 ERROR EimDbCreator:141 - null
+2019-05-15 12:24:29 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-15 12:24:30 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-15 12:24:30 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-15 12:24:30 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-15 12:24:30 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 12:24:30 ERROR EimDbCreator:141 - null
+2019-05-15 12:24:30 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-15 12:24:30 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-15 12:24:30 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 12:24:30 ERROR EimDbCreator:141 - null
+2019-05-15 12:24:30 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-15 12:24:30 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-15 12:24:30 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 12:24:30 ERROR EimDbCreator:141 - null
+2019-05-15 15:47:52 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-15 15:47:52 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-15 15:47:52 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-15 15:47:52 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-15 15:47:52 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 15:47:52 ERROR EimDbCreator:141 - null
+2019-05-15 15:47:52 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-15 15:47:52 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-15 15:47:52 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 15:47:52 ERROR EimDbCreator:141 - null
+2019-05-15 15:47:52 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-15 15:47:52 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-15 15:47:52 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 15:47:52 ERROR EimDbCreator:141 - null
+2019-05-15 15:49:06 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-15 15:49:06 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-15 15:49:06 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-15 15:49:06 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-15 15:49:06 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 15:49:06 ERROR EimDbCreator:141 - null
+2019-05-15 15:49:06 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-15 15:49:06 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-15 15:49:06 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 15:49:06 ERROR EimDbCreator:141 - null
+2019-05-15 15:49:06 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-15 15:49:06 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-15 15:49:06 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 15:49:06 ERROR EimDbCreator:141 - null
+2019-05-15 19:22:53 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-15 19:22:53 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-15 19:22:53 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-15 19:22:53 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-15 19:22:53 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 19:22:53 ERROR EimDbCreator:141 - null
+2019-05-15 19:22:53 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-15 19:22:53 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-15 19:22:53 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 19:22:53 ERROR EimDbCreator:141 - null
+2019-05-15 19:22:53 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-15 19:22:53 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-15 19:22:53 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-15 19:22:53 ERROR EimDbCreator:141 - null
+2019-05-16 10:09:53 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-16 10:09:53 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-16 10:09:53 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-16 10:09:53 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-16 10:09:53 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 10:09:53 ERROR EimDbCreator:141 - null
+2019-05-16 10:09:53 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-16 10:09:53 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-16 10:09:53 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 10:09:53 ERROR EimDbCreator:141 - null
+2019-05-16 10:09:53 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-16 10:09:53 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-16 10:09:53 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 10:09:53 ERROR EimDbCreator:141 - null
+2019-05-16 11:47:11 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-16 11:47:11 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-16 11:47:11 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-16 11:47:11 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-16 11:47:11 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 11:47:11 ERROR EimDbCreator:141 - null
+2019-05-16 11:47:11 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-16 11:47:11 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-16 11:47:11 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 11:47:11 ERROR EimDbCreator:141 - null
+2019-05-16 11:47:11 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-16 11:47:11 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-16 11:47:11 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 11:47:11 ERROR EimDbCreator:141 - null
+2019-05-16 12:39:34 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-16 12:39:34 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-16 12:39:34 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-16 12:39:34 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-16 12:39:34 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 12:39:34 ERROR EimDbCreator:141 - null
+2019-05-16 12:39:34 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-16 12:39:34 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-16 12:39:34 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 12:39:34 ERROR EimDbCreator:141 - null
+2019-05-16 12:39:34 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-16 12:39:34 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-16 12:39:34 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 12:39:34 ERROR EimDbCreator:141 - null
+2019-05-16 12:53:49 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-16 12:53:49 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-16 12:53:49 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-16 12:53:49 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-16 12:53:49 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 12:53:49 ERROR EimDbCreator:141 - null
+2019-05-16 12:53:49 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-16 12:53:49 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-16 12:53:49 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 12:53:49 ERROR EimDbCreator:141 - null
+2019-05-16 12:53:49 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-16 12:53:49 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-16 12:53:49 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 12:53:49 ERROR EimDbCreator:141 - null
+2019-05-16 17:11:19 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-16 17:11:19 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-16 17:11:19 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-16 17:11:19 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-16 17:11:19 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 17:11:19 ERROR EimDbCreator:141 - null
+2019-05-16 17:11:19 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-16 17:11:19 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-16 17:11:19 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 17:11:19 ERROR EimDbCreator:141 - null
+2019-05-16 17:11:19 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-16 17:11:19 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-16 17:11:19 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 17:11:19 ERROR EimDbCreator:141 - null
+2019-05-16 20:26:24 INFO  Properties:41 - Properties loaded from /WEB-INF/bootstrap.properties
+2019-05-16 20:26:24 ERROR EimDbCreator:60 - Error creating EIM database: error parsing url : Incorrect port value : null
+2019-05-16 20:26:24 ERROR EimDbCreator:199 - Error has occurred on table agent check
+2019-05-16 20:26:24 ERROR EimDbCreator:137 - Error has occurred on table agent creation
+2019-05-16 20:26:24 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 20:26:24 ERROR EimDbCreator:141 - null
+2019-05-16 20:26:24 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration check
+2019-05-16 20:26:24 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration creation
+2019-05-16 20:26:24 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 20:26:24 ERROR EimDbCreator:141 - null
+2019-05-16 20:26:24 ERROR EimDbCreator:199 - Error has occurred on table agent_configuration_control check
+2019-05-16 20:26:24 ERROR EimDbCreator:137 - Error has occurred on table agent_configuration_control creation
+2019-05-16 20:26:24 ERROR EimDbCreator:140 - error parsing url : Incorrect port value : null
+2019-05-16 20:26:24 ERROR EimDbCreator:141 - null

--- a/eim/eim-rest-api/src/main/java/io/elastest/eim/config/Dictionary.java
+++ b/eim/eim-rest-api/src/main/java/io/elastest/eim/config/Dictionary.java
@@ -72,7 +72,8 @@ public class Dictionary {
 	public static String SUT_ACTION_STRESS_CPU = "stress";
 	public static String NO_ACTION_PACKETLOSS = "";
 	public static String NO_ACTION_STRESS_CPU = "";
-	
+	public static String PROPERTY_TEMPLATES_BEATS_ITEM_ANSIBLE = "templates.beats.item.ansible";
+
 	
 	// USED TO INSTALL/REMOVE FEATURES IN SUT
 	public static String INSTALL = "install";
@@ -96,7 +97,7 @@ public class Dictionary {
 	 //public static final String DBURL ="jdbc:mariadb://" + System.getenv("ET_EIM_MONGO_HOST") + ":" + DBPORT + "/eim";
 	 public static final String DBURL ="jdbc:mariadb://" + System.getenv("ET_EDM_MYSQL_HOST") + ":" + System.getenv("ET_EDM_MYSQL_PORT") + "/" + DBNAME;
 	 //public static final String DBURL ="jdbc:mariadb://" + "172.17.0.2" + ":" + "3306" + "/" + DBNAME;
-
+	
 	 // PREFIX FOR AGENTS ID
 	 public static String PREFIX_AGENTS_ID = "iagent";
 }

--- a/eim/eim-rest-api/src/main/java/io/elastest/eim/database/AgentConfigurationControlRepository.java
+++ b/eim/eim-rest-api/src/main/java/io/elastest/eim/database/AgentConfigurationControlRepository.java
@@ -43,6 +43,10 @@ public class AgentConfigurationControlRepository {
 	
 	public boolean deleteAgentCfg(String agentId) {
 		return eimDbCfgManager.deleteAgentConfiguration(agentId);    
+	}
+
+	public List<AgentConfigurationDatabaseControl> getPacketLoss(String agentId) {
+		return eimDbCfgManager.getPacketLoss(agentId);
 	}	
 	
 

--- a/eim/eim-rest-api/src/main/java/io/elastest/eim/database/mysql/EimDbAgentCfgManager.java
+++ b/eim/eim-rest-api/src/main/java/io/elastest/eim/database/mysql/EimDbAgentCfgManager.java
@@ -316,6 +316,7 @@ public class EimDbAgentCfgManager {
 		PreparedStatement pstDeleteAgent = null;
 		
 		try {
+			
 			String deleteSQL = "DELETE FROM " + Dictionary.DBTABLE_AGENT_CONFIGURATION + " WHERE AGENT_ID = ?";
 			pstDeleteAgent = conn.prepareStatement(deleteSQL);
 			pstDeleteAgent.setString(1, agentId);

--- a/eim/eim-rest-api/src/main/java/io/elastest/eim/templates/BeatsTemplateManager.java
+++ b/eim/eim-rest-api/src/main/java/io/elastest/eim/templates/BeatsTemplateManager.java
@@ -13,33 +13,46 @@
 
 package io.elastest.eim.templates;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.log4j.Logger;
 
-import ch.qos.logback.core.pattern.color.ANSIConstants;
 import io.elastest.eim.config.Dictionary;
+import io.elastest.eim.database.AgentConfigurationControlRepository;
+import io.elastest.eim.database.mysql.EimDbAgentCfgControlManager;
+import io.elastest.eim.database.mysql.EimDbAgentCfgManager;
 import io.elastest.eim.utils.TemplateUtils;
 import io.swagger.model.AgentConfiguration;
+import io.swagger.model.AgentConfigurationDatabaseControl;
 import io.swagger.model.AgentFull;
 
 public class BeatsTemplateManager {
 
-private static Logger logger = Logger.getLogger(BeatsTemplateManager.class);
-	
+	private static Logger logger = Logger.getLogger(BeatsTemplateManager.class);
+
 	private String executionDate = "";
 	private AgentFull agent;
 	private String action;
 	private AgentConfiguration agentCfg;
+	private AgentConfigurationControlRepository generateBeatsScriptRemovePacketLossCommand;
 	private String cfgFilePath = "";
-	
+
 	public BeatsTemplateManager(AgentFull agent, String executionDate, String action, String cfgFilePath) {
 		this.agent = agent;
 		this.executionDate = executionDate;
 		this.action = action;
 		this.cfgFilePath = cfgFilePath;
 	}
-	
+
 	/**
-	 * Only needed when the beats are going to be installed. It must be called before call execute method
+	 * Only needed when the beats are going to be installed. It must be called
+	 * before call execute method
+	 * 
 	 * @param agentCfg
 	 */
 	public void setConfiguration(AgentConfiguration agentCfg) {
@@ -47,53 +60,124 @@ private static Logger logger = Logger.getLogger(BeatsTemplateManager.class);
 		System.out.println(this.agentCfg.toString());
 		logger.info(this.agentCfg.toString());
 	}
-	
+
+	private List<String> explorePacketLossCommand() {
+		Connection conn = null;
+		List<String> packetLossValues = new ArrayList<String>();
+
+		PreparedStatement pstSelectPacketLoss = null;
+		EimDbAgentCfgControlManager aux = new EimDbAgentCfgControlManager();
+
+		try {
+			conn = aux.getConnection();
+		} catch (SQLException e1) {
+			// TODO Auto-generated catch block
+			e1.printStackTrace();
+		}
+
+		try {
+			String sql = "SELECT PACKETLOSS FROM " + Dictionary.DBTABLE_AGENT_CONFIGURATION_CONTROL
+					+ " WHERE AGENT_ID = ?";
+			logger.info("Sql is: " + sql);
+			System.out.println("SQL is: " + sql);
+
+			pstSelectPacketLoss = conn.prepareStatement(sql);
+			pstSelectPacketLoss.setString(1, agent.getAgentId());
+
+			logger.info("SQL is: " + sql);
+			System.out.println("SQL is: " + sql);
+			ResultSet rs = pstSelectPacketLoss.executeQuery();
+
+			while (rs.next()) {
+				logger.info("PACKETLOSS property for agentId: " + agent.getAgentId());
+				System.out.println("PACKETLOSS property for agentId: " + agent.getAgentId());
+
+				String value = rs.getString(rs.getRow()).replaceAll("-A", "");
+
+				packetLossValues.add(value);
+				logger.info("Packetloss captured from BBDD: " + value);
+				System.out.println("Packetloss captured from BBDD: " + value);
+
+			}
+		} catch (SQLException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} finally {
+
+			if (pstSelectPacketLoss != null)
+				try {
+					pstSelectPacketLoss.close();
+				} catch (SQLException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+		}
+		return packetLossValues;
+	}
+
 	public int execute() {
-		
-		if (action.equals(Dictionary.INSTALL)) {		
+
+		if (action.equals(Dictionary.INSTALL)) {
 			logger.info("Preparing the execution of beats install playbook for agent " + agent.getAgentId());
-			//generate files for execution: playbook and script
-			//the fourth argument is the user, that is not used in this playbook. The agent is also registrated, so in this case,
-			//elastest user is the one used.
+			// generate files for execution: playbook and script
+			// the fourth argument is the user, that is not used in this playbook. The agent
+			// is also registrated, so in this case,
+			// elastest user is the one used.
 			String generatedPlaybookPath = TemplateUtils.generateBeatsPlaybook(executionDate, agent, action, agentCfg);
 			if (generatedPlaybookPath != "") {
-				String generatedScriptPath = TemplateUtils.generateBeatsScript(executionDate, agent, generatedPlaybookPath, cfgFilePath, action);	
+				String generatedScriptPath = TemplateUtils.generateBeatsScript(executionDate, agent,
+						generatedPlaybookPath, cfgFilePath, action);
 				if (generatedScriptPath != null) {
-					//execute generated files
+					// execute generated files
 					return TemplateUtils.executeScript("beats", generatedScriptPath, executionDate, agent);
-				}
-				else {
-					logger.error("ERROR generating script for execution for agent " + agent.getAgentId( )+ ". Check logs please");
+				} else {
+					logger.error("ERROR generating script for execution for agent " + agent.getAgentId()
+							+ ". Check logs please");
 					return -1;
 				}
-			}
-			else {
-				logger.error("ERROR generating playbook for execution for agent " + agent.getAgentId( )+ ". Check logs please");
+			} else {
+				logger.error("ERROR generating playbook for execution for agent " + agent.getAgentId()
+						+ ". Check logs please");
 				return -1;
-			}		
-			//TODO move template to history execution path
+			}
+			// TODO move template to history execution path
+		} else if (action.equals(Dictionary.REMOVE)) {
+
+			List<String> packetLossValues = explorePacketLossCommand();
+
+			if (packetLossValues != null) {
+				String generatedPlaybookPath = TemplateUtils.generateBeatsPlaybookRemovePacketLossCommands(
+						executionDate, agent, action, packetLossValues, null);
+				if (generatedPlaybookPath != "") {
+					String generatedScriptPath = TemplateUtils.generateBeatsScript(executionDate, agent,
+							generatedPlaybookPath, cfgFilePath, action);
+					return TemplateUtils.executeScript("beats", generatedScriptPath, executionDate, agent);
+				}
+				logger.error("ERROR generating script for execution for agent " + agent.getAgentId()
+						+ ". Check logs please");
+				return -1;
+			}
+
+			else {
+				logger.info("Preparing the execution of beats remove playbook for agent " + agent.getAgentId());
+
+				String generatedPlaybookPath = TemplateUtils.generateBeatsPlaybook(executionDate, agent, action, null);
+
+				if (generatedPlaybookPath != "") {
+					String generatedScriptPath = TemplateUtils.generateBeatsScript(executionDate, agent,
+							generatedPlaybookPath, cfgFilePath, action);
+					if (generatedScriptPath != null) {
+						// execute generated files
+						return TemplateUtils.executeScript("beats", generatedScriptPath, executionDate, agent);
+					} else {
+						logger.error("ERROR generating script for execution for agent " + agent.getAgentId()
+								+ ". Check logs please");
+						return -1;
+					}
+				}
+			}
 		}
-		else if (action.equals(Dictionary.REMOVE)) {
-			logger.info("Preparing the execution of beats remove playbook for agent " + agent.getAgentId());
-			String generatedPlaybookPath = TemplateUtils.generateBeatsPlaybook(executionDate, agent, action, null);
-			if (generatedPlaybookPath != "") {
-				String generatedScriptPath = TemplateUtils.generateBeatsScript(executionDate, agent, generatedPlaybookPath, cfgFilePath, action);	
-				if (generatedScriptPath != null) {
-					//execute generated files
-					return TemplateUtils.executeScript("beats", generatedScriptPath, executionDate, agent);
-				}
-				else {
-					logger.error("ERROR generating script for execution for agent " + agent.getAgentId( )+ ". Check logs please");
-					return -1;
-				}
-			}
-			else {
-				logger.error("ERROR generating playbook for execution for agent " + agent.getAgentId( )+ ". Check logs please");
-				return -1;
-			}
-		}	
 		return -1;
 	}
-	
-	
+
 }

--- a/eim/eim-rest-api/src/main/java/io/elastest/eim/templates/SshTemplateManager.java
+++ b/eim/eim-rest-api/src/main/java/io/elastest/eim/templates/SshTemplateManager.java
@@ -76,9 +76,8 @@ public class SshTemplateManager {
 			else {
 				logger.error("ERROR generating playbook for delete execution for agent " + agent.getAgentId( )+ ". Check logs please");
 				return -1;
-			}	
-			
-		}	
+			}
+		}
 		return -1;
 
 	}

--- a/eim/eim-rest-api/src/main/java/io/swagger/api/impl/AgentApiServiceImpl.java
+++ b/eim/eim-rest-api/src/main/java/io/swagger/api/impl/AgentApiServiceImpl.java
@@ -19,6 +19,9 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.List;
@@ -73,29 +76,30 @@ public class AgentApiServiceImpl extends AgentApiService {
     			//remove beats
     			status = -1;
 	    		//beats uninstallation
-	            BeatsTemplateManager beatsTemplateManager = new BeatsTemplateManager(agent, executionDate, Dictionary.REMOVE, getAnsibleCfgFilePathForAgent(agent));	            
+	            BeatsTemplateManager beatsTemplateManager = new BeatsTemplateManager(agent, executionDate, Dictionary.REMOVE, getAnsibleCfgFilePathForAgent(agent));
+	            logger.info("beatsTemplateManager" + beatsTemplateManager.toString());
+	            System.out.println("beatsTemplateManager"+ beatsTemplateManager.toString());
+	            
 	            status = beatsTemplateManager.execute();
 	            if (status == 0) {
 	            	logger.info("Successful execution for the delete script generated to agent " + agent.getAgentId());
 	            	
 	            	//delete agent configuration
 	            	boolean deleted = agentCfgDb.deleteAgentCfg(agentId);
-	            	// delete agent configuration control
+	            	//delete agent configuration control
 	            	boolean deleted_execbeat = agentCfgControlDB.deleteAgentCfg(agentId);
 	            	
 	        		if (deleted) {
-	        			logger.info("Successful deleted from database agent_configuration table -->  agent " + agent.getAgentId());
-	        			//return Response.ok().entity(agent).build();	        		
+	        			logger.info("Successful deleted from database agent_configuration table -->  agent " + agent.getAgentId());	        		
 	        		}
-	        		if (deleted_execbeat) {
+	        		if (deleted_execbeat) {		
 	        			logger.info("Successful deleted from database agent_configuration_control table -->  agent configuration" + agent.getAgentId());
 	        		}
 	        		else {
 	        			logger.error("ERROR deleting agent configuration " + agent.getAgentId() + " from database");
 	        			return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ApiResponseMessage(ApiResponseMessage.ERROR, "Agent " + agentId + " cannot be deleted from database, check logs please")).build();
 	        		}
-	        	
-	            }
+	        	}
 	            else {	            	
 	            	logger.error("ERROR executing the beats script for agent " + agent.getAgentId() + ". Check logs please");
 	            	return Response.serverError().entity(new ApiResponseMessage(ApiResponseMessage.ERROR, "Result of the execution has been: " + status + " " )).build();
@@ -115,20 +119,19 @@ public class AgentApiServiceImpl extends AgentApiService {
 	            	return Response.serverError().entity(new ApiResponseMessage(ApiResponseMessage.ERROR, "Result of the execution has been: " + status + " " )).build();
 	            }
     		}
-    		
-    		//delete from db
-    		boolean deleted_execbeat = agentCfgControlDB.deleteAgentCfg(agentId);
+    
+    		//Delete agent from db
     		boolean deleted = agentDb.deleteAgent(agentId);
+        	boolean deleted_execbeat = agentCfgControlDB.deleteAgentCfg(agentId);
+
+    		
     		if (deleted) {
     			logger.info("Successful deleted from database agent_configuration table -->  agent " + agent.getAgentId());
     			//return Response.ok().entity(agent).build();    		
     		}
     		if (deleted_execbeat) {
-    			logger.info("Successful deleted from database agent_configuration_control table -->  agent configuration" + agent.getAgentId());
-    		}
-    		else {
-    			logger.error("ERROR deleting agent " + agent.getAgentId() + " from database");
-    			return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ApiResponseMessage(ApiResponseMessage.ERROR, "Agent " + agentId + " cannot be deleted from database, check logs please")).build();
+    			logger.info("Successful deleted from database agent_configuration_control table -->  agent " + agent.getAgentId());
+
     		}
     		
     		try {
@@ -464,6 +467,8 @@ public class AgentApiServiceImpl extends AgentApiService {
     }
     
     private String getAnsibleCfgFilePathForAgent(AgentFull agent) {
+    	
+    	//var/ansible/ssh/hosts/iagent01/host_iagent01_cfg"
     	String a  = Properties.getValue(Dictionary.PROPERTY_TEMPLATES_SSH_EXECUTIONPATH) + 
     			Properties.getValue(Dictionary.PROPERTY_TEMPLATES_SSH_HOSTS_FOLDER) +
     			agent.getAgentId() + "/" + "host_" + agent.getAgentId() + "_cfg";

--- a/eim/eim-rest-api/src/main/webapp/WEB-INF/bootstrap.properties
+++ b/eim/eim-rest-api/src/main/webapp/WEB-INF/bootstrap.properties
@@ -26,6 +26,7 @@ templates.beats.install.plabook=playbook-install-beat-execbeat.yml
 templates.beats.joker.args.execbeat=##args##
 templates.beats.joker.stream.execbeat=##command##
 templates.beats.joker.cronExpression.execbeat=##cron_expression##
+templates.beats.item.ansible=##item##
 
 templates.beats.remove.playbook=playbook-delete-beats-template.yml
 templates.beats.install.execution_playbook_prefix=playbook-beats-install-


### PR DESCRIPTION
It works when you request as below:
```
curl -i -X DELETE -H "Content-Type:application/json" -H "Accept:application/json" http://localhost:8080/eim/api/agent/iagent0/unmonitor

```
The process is: 
1 - It set the flag MONITORED from ```agent``` table to Zero
2 - Its delete ```agent_configuration```  table from Mysql
3- Its explore ```agent_configuration_control``` table on Mysql service and  then remove iptables rules from SUT using Ansible playbook

Ansible Specific code:
```
- name: Check if iptables list is not empty
    command: sudo iptables --list --line-numbers
    register: iptables_lists_exists
  
 - name: "Restore default iptables rules of SUT"
    shell: sudo iptables -D {{ item }}
    with_items: 
      -  "##item##"
    when: iptables_lists_exists!="0"
```